### PR TITLE
A couple of t-test transducer implementations

### DIFF
--- a/src/statistics_is_easy/chapter_1.clj
+++ b/src/statistics_is_easy/chapter_1.clj
@@ -175,7 +175,7 @@
 
 ;;;; Option A: calculate summary statistics independently ;;;;
 ;;
-;; (We're using t-test, not simple-t-testm because the latter compares a sample
+;; (We're using t-test, not simple-t-test because the latter compares a sample
 ;; against a population whereas we have two samples to compare
 
 ;; First define reducing function which returns summary statistics:
@@ -200,14 +200,13 @@
 ;; Then define reducing function appropriate for this single sequence:
 (defn t-test-reducing-function
   [label-a label-b]
-  (redux.core/post-complete
-   (redux.core/facet
-    (redux.core/fuse
-     {:mean kcore/mean
-      :sd kcore/standard-deviation
-      :n ((remove nil?) kcore/count)})
-    [label-a label-b])
-   (comp ktest/p-value (partial apply ktest/t-test))))
+  (-> {:mean kcore/mean
+       :sd kcore/standard-deviation
+       :n ((remove nil?) kcore/count)}
+      (redux.core/fuse)
+      (redux.core/facet [label-a label-b])
+      (redux.core/post-complete
+       (comp ktest/p-value (partial apply ktest/t-test)))))
 
 (transduce identity (t-test-reducing-function :placebo :drug) data)
 ;; => 0.0018017423704935023


### PR DESCRIPTION
`kixi.stats` is really all about using transducers to solve aggregation problems, and so the functions in `kixi.stats.core` are designed to be used as reducing functions passed to e.g. `transduce` and friends. You got a p-value rather than an exception because the functions all have a single-arity implementation which was able to cope with your input, but their return values were not what you wanted at all: `(kcore/mean placebo)` ~= 1.06 rather than 50.7.

I've shown two options for using them as intended:
* Option A: calculate the summary statistics independently using transduce twice
* Option B: calculate the p-value in a single custom reducing function passed to transduce once (all of the input data is passed in a single sequence)

I'm using reducing function combinators from `redux` simply because it's already included with `kixi.stats` but you could write your own or use a different library (e.g. https://github.com/cgrand/xforms).

In both cases we are creating (the same) summary statistics which are then passed to `t-test`. I've switched from `simple-t-test` because the latter is supposed to be used for comparing a single sample against expected population parameters (you'll see the arguments are different because there's only one sample involved with a simple t-test).

This is all a lot more involved than simply using fastmath because the use-case doesn't really require any of the benefits that transducers bring! Whether or not you use either of the options above, I hope it's reassuring (and educational) to see how `kixi.stats` can arrive at the same answer.